### PR TITLE
T1059: Support receiving IPv6 router advertisements.

### DIFF
--- a/interface-templates/ipv6/address/autoconf/node.def
+++ b/interface-templates/ipv6/address/autoconf/node.def
@@ -9,12 +9,7 @@ update:
 	if [ -e /proc/sys/net/ipv6/conf/$IFNAME/autoconf ]; then
 	    echo "Enabling address auto-configuration for $IFNAME"
 	    sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/$IFNAME/autoconf"
-	    forwarding=`cat /proc/sys/net/ipv6/conf/$IFNAME/forwarding`
-	    if [ $forwarding = 1 ]; then
-		echo "Warning: IPv6 forwarding is currently enabled."
-		echo "         IPv6 address auto-configuration will not be performed"
-                echo "         unless IPv6 forwarding is disabled."
-	    fi
+	    sudo sh -c "echo 2 > /proc/sys/net/ipv6/conf/$IFNAME/accept_ra"
 	else
 	    echo "Address auto-configuration will be enabled when interface comes up."
 	fi
@@ -22,6 +17,7 @@ update:
 delete:
 	if [ -e /proc/sys/net/ipv6/conf/$IFNAME/autoconf ]; then
 	    sudo sh -c "echo 0 > /proc/sys/net/ipv6/conf/$IFNAME/autoconf"
+	    sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/$IFNAME/accept_ra"
 	else
 	    echo "Address auto-configuration will be disabled when interface comes up."
 	fi


### PR DESCRIPTION
Since we're a router, we're always forwarding. Rather than asking the user to turn off forwarding (which would preclude most interesting use cases), configure listening to router advertisements when autoconfiguration is requested.